### PR TITLE
Blinkのcookieだとvalueのないキーが存在するようで、例外扱いするべきではなかった。

### DIFF
--- a/Net4.5/SnkLib.App.CookieGetter/Importers/BlinkCookieImporter.cs
+++ b/Net4.5/SnkLib.App.CookieGetter/Importers/BlinkCookieImporter.cs
@@ -72,14 +72,23 @@ namespace SunokoLibrary.Application.Browsers
             if (formatVersion >= 7)
             {
                 var cipher = data[0] as byte[];
-                if (cipher == null || cipher.Length == 0)
+                if (cipher == null)
+                {
                     throw new CookieImportException(
                         "Cookieファイルから暗号化データを取得できませんでした。", CookieImportState.ConvertError);
-                var plain = Win32Api.DecryptProtectedData(cipher);
-                if (plain == null)
-                    throw new CookieImportException(
-                        "Cookieの暗号化データを復号化できませんでした。", CookieImportState.ConvertError);
-                baseObj.Value = Encoding.UTF8.GetString(plain);
+                }
+                else if (cipher.Length == 0)
+                {
+                    baseObj.Value = "";
+                }
+                else
+                {
+                    var plain = Win32Api.DecryptProtectedData(cipher);
+                    if (plain == null)
+                        throw new CookieImportException(
+                            "Cookieの暗号化データを復号化できませんでした。", CookieImportState.ConvertError);
+                    baseObj.Value = Encoding.UTF8.GetString(plain);
+                }
             }
             else
                 baseObj.Value = data[0] as string;


### PR DESCRIPTION
Valueが空でも例外にしないよう変更。
データ型が違う場合 ((data[0] as byte[])==null) は
テーブル参照失敗か何かだと思うのでエラーにしておく。

// twitterの件です
// 初めてのgit/githubなので間違い/不都合あればご指摘ください
