### PR TITLE
Geckoのプロファイルが正しく読めていなかった。

### DIFF
--- a/Net4.5/SnkLib.App.CookieGetter/Factories/GeckoImporterFactory.cs
+++ b/Net4.5/SnkLib.App.CookieGetter/Factories/GeckoImporterFactory.cs
@@ -77,9 +77,15 @@ namespace SunokoLibrary.Application.Browsers
                     return results.ToArray();
 
                 using (var sr = new StreamReader(profileListPath))
+                {
+                    bool recheck = false;
+                    var line = "";
                     while (!sr.EndOfStream)
                     {
-                        var line = sr.ReadLine();
+                        if (!recheck)
+                           line = sr.ReadLine();
+                        recheck = false;
+
                         if (line.StartsWith("[Profile"))
                         {
                             var prof = new UserProfile();
@@ -88,8 +94,10 @@ namespace SunokoLibrary.Application.Browsers
                             {
                                 var l = sr.ReadLine();
                                 if (l.StartsWith("["))
-                                {
-                                    break;  // 次のデータブロックが開始 : このデータ終了
+                                {   // 次のセクションが開始 : このセクション終了
+                                    recheck = true;
+                                    line = l;   // 次のセクションチェックのために入れておく
+                                    break;
                                 }
                                 var pair = ParseKeyValuePair(l);
                                 switch (pair.Key)
@@ -116,6 +124,7 @@ namespace SunokoLibrary.Application.Browsers
                                 results.Add(prof);
                         }
                     }
+                }
                 return results.ToArray();
             }
             static KeyValuePair<string, string> ParseKeyValuePair(string line)

--- a/Net4.5/SnkLib.App.CookieGetter/Factories/GeckoImporterFactory.cs
+++ b/Net4.5/SnkLib.App.CookieGetter/Factories/GeckoImporterFactory.cs
@@ -83,23 +83,32 @@ namespace SunokoLibrary.Application.Browsers
                         if (line.StartsWith("[Profile"))
                         {
                             var prof = new UserProfile();
-                            var pair = ParseKeyValuePair(line);
-                            switch (pair.Key)
+
+                            while (!sr.EndOfStream)
                             {
-                                case "Name":
-                                    prof.Name = pair.Value;
-                                    break;
-                                case "IsRelative":
-                                    prof.IsRelative = pair.Value == "1";
-                                    break;
-                                case "Path":
-                                    prof.Path = pair.Value.Replace('/', '\\');
-                                    if (prof.IsRelative)
-                                        prof.Path = System.IO.Path.Combine(moz_path, prof.Path);
-                                    break;
-                                case "Default":
-                                    prof.IsDefault = pair.Value == "1";
-                                    break;
+                                var l = sr.ReadLine();
+                                if (l.StartsWith("["))
+                                {
+                                    break;  // 次のデータブロックが開始 : このデータ終了
+                                }
+                                var pair = ParseKeyValuePair(l);
+                                switch (pair.Key)
+                                {
+                                    case "Name":
+                                        prof.Name = pair.Value;
+                                        break;
+                                    case "IsRelative":
+                                        prof.IsRelative = pair.Value == "1";
+                                        break;
+                                    case "Path":
+                                        prof.Path = pair.Value.Replace('/', '\\');
+                                        if (prof.IsRelative)
+                                            prof.Path = System.IO.Path.Combine(moz_path, prof.Path);
+                                        break;
+                                    case "Default":
+                                        prof.IsDefault = pair.Value == "1";
+                                        break;
+                                }
                             }
                             if (prof.IsDefault)
                                 results.Insert(0, prof);


### PR DESCRIPTION
Gecko のプロファイルが存在すると、チェックしに行ったときに prof.Path が null になり、
確定で ArgumentNullException 例外が発生していた模様。

とりあえずプロファイルがあったらデータを埋めるようにしたが、
%AppData%\Roaming\Mozilla\Firefox\profile.ini のファイルが壊れていた時、 たとえば

```
[Profile1]
[EOF]
```

このような場合はデータが取得できず、Path.Combine() で ArgumentNullException 例外が発生してしまう。

一応上記でもプロファイルの形式には叶っていると思われるものの、
かなり稀なケースとは思うので対処が必要であれば別件で行うべきと判断。
丁寧にやるのであれば result.Insert() / result.add() の前にチェックをかけ、
CookieImportException あたりを投げるのが妥当なところだろうか？
